### PR TITLE
Php dependancy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,8 @@ roundcube__nginx_access_policy: ''
 # List of PHP5 packages required by Roundcube.
 roundcube__php5_packages: [ 'php-auth-sasl', 'php5-gd', 'php5-intl', 'php5-json',
                            'php5-mcrypt', 'php-mail-mime', 'php-mail-mimedecode',
-                           'php-net-smtp', 'php-net-socket', 'php-pear' ]
+                           'php-net-smtp', 'php-net-socket', 'php-pear',
+                           'php-net-idna2' ]
 
 
 # ---------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ roundcube__nginx_access_policy: ''
 roundcube__php5_packages: [ 'php-auth-sasl', 'php5-gd', 'php5-intl', 'php5-json',
                            'php5-mcrypt', 'php-mail-mime', 'php-mail-mimedecode',
                            'php-net-smtp', 'php-net-socket', 'php-pear',
-                           'php-net-idna2' ]
+                           'php-net-idna2', 'php-net-ldap3' ]
 
 
 # ---------------------------------------


### PR DESCRIPTION
Some more packages needed by roundcube
The installer script wants php-net-idna2
The ldap address book needs the php-net-ldap3 library.

php5-pspell and stuff might stay in the extra_packages config but that should be discussed.