### PR TITLE
Properly indent 'mariadb__server' attribute in playbook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Fixed
 
 - Fix syntax error in :envvar:`roundcube__database_schema` variable definition. [cultcom]
 
+- Fix MySQL database schema setup when using remote database by adjusting
+  indentation of example playbook. [ganto_]
+
 
 `debops-contrib.roundcube v0.1.1_` - 2016-08-03
 -----------------------------------------------

--- a/docs/playbooks/roundcube.yml
+++ b/docs/playbooks/roundcube.yml
@@ -35,7 +35,7 @@
           home: '{{ roundcube__home }}'
           system: True
           priv_aux: False
-          mariadb_server: '{{ roundcube__database_map[roundcube__database].dbhost }}'
+      mariadb__server: '{{ roundcube__database_map[roundcube__database].dbhost }}'
       when: roundcube__database_map[roundcube__database].dbtype == 'mysql'
 
     - role: debops-contrib.roundcube


### PR DESCRIPTION
Fixes issue with setting up the MySQL backend on a different server than localhost.