### PR TITLE
Fix link to deprecated debops.php5 role repository

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ The current role maintainer_ is ganto_.
 
 .. _debops-contrib.roundcube master: https://github.com/debops-contrib/ansible-roundcube/compare/v0.1.2...master
 
+Fixed
+~~~~~
+
+- Fix documentation build error due to deleted link definition to deprecated
+  `debops.php5` role repository. [ganto_]
+
+
 `debops-contrib.roundcube v0.1.2_` - 2017-03-09
 -----------------------------------------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -311,7 +311,8 @@ roundcube__php5_packages: [ 'php-auth-sasl', 'php5-gd', 'php5-intl', 'php5-json'
 
 # .. envvar:: roundcube__php5_pool
 #
-# PHP pool managed by the debops.php5_ role.
+# PHP pool managed by the `debops.php5 <https://github.com/debops/ansible-php5>`_
+# role.
 roundcube__php5_pool:
   enabled: True
   name: 'roundcube'


### PR DESCRIPTION
Link to role repository was removed in upstream definition
with debops/docs#260.